### PR TITLE
Check if mastering metadata exists in side frame

### DIFF
--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -424,7 +424,9 @@ static inline double avr2d(AVRational a) {
           break;
         }
         
-        metadata = (AVMasteringDisplayMetadata *)av_frame_get_side_data(pFrame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA)->data;
+        AVFrameSideData* side_data = av_frame_get_side_data(pFrame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
+        
+        if(side_data) metadata = (AVMasteringDisplayMetadata *) side_data->data;
         break;
       }
     }


### PR DESCRIPTION
Was crashing if mastering metadata didn't exist in frames/metadata container initially, this fixes it by checking if exists before pulling metadata from frame.

(Not sure if its necessary to try and pull metadata from frames as it seems if they aren't in the video container the metadata generally doesn't exist). 